### PR TITLE
Add Docker / Compose files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:edge
+
+ENV PROJECT_PATH=/basicmac
+
+RUN mkdir -p $PROJECT_PATH
+WORKDIR $PROJECT_PATH
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+RUN apk add --no-cache \
+	ca-certificates \
+	make \
+	git \
+	bash \
+	gcc-arm-none-eabi \
+	newlib-arm-none-eabi \
+	python3 \
+	openocd \
+	alpine-sdk \
+	screen
+
+RUN pip3 install \
+	Click \
+	intelhex \
+	PyYAML
+
+ADD tools/openocd/stlink-rules.tgz /etc/udev/rules.d/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  basicmac:
+    privileged: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/basicmac
+      - /dev/bus/usb:/dev/bus/usb
+      - /dev/ttyACM0:/dev/ttyACM0
+


### PR DESCRIPTION
This sets up a working development environment using:

$ docker-compose run --rm basicmac bash

Potentially this could be useful for users to get started as it automates the installation of requirements. Using this setup I was able to compile the bootloader, example join project and flash both to the device (using a Linux host machine).